### PR TITLE
[Ftx] max 객체 할당오류 수정

### DIFF
--- a/Assets/Scripts/Utils/RangedStat.cs
+++ b/Assets/Scripts/Utils/RangedStat.cs
@@ -18,7 +18,7 @@ namespace OnGame.Utils
 
     public RangedStat(int maxValue, int value, StatOperator<int> maxOper = null)
     {
-      Max = maxValue;
+      max = new Stat<int>(maxValue);
       Value = value;
       MaxOper = maxOper;
     }

--- a/Assets/Scripts/Utils/Stat.cs
+++ b/Assets/Scripts/Utils/Stat.cs
@@ -10,12 +10,12 @@ namespace OnGame.Utils
     public T Value => oper != null ? oper(baseValue) : baseValue;
     public StatOperator<T> oper;
     
-    public Stat(T baseValue, StatOperator<T> oper)
+    public Stat(T baseValue, StatOperator<T> oper = null)
     {
       this.baseValue = baseValue;
       this.oper = oper;
     }
-    
+
     public static implicit operator T(Stat<T> stat) => stat.Value;
   }
 }


### PR DESCRIPTION
* RangeStat 생성자에서 max 객체를 할당하지 않아 발생하는 Null 문제 수정